### PR TITLE
Rechtschreibfehler korrigiert

### DIFF
--- a/lss-manager-v3/lss-manager-v3.dev.js
+++ b/lss-manager-v3/lss-manager-v3.dev.js
@@ -303,7 +303,7 @@ lssm.Module = {
         },
         active: false,
         description: {
-            de: 'Funktion um sebst erstellte VGE zu speichern.',
+            de: 'Funktion um selbst erstellte VGE zu speichern.',
             en: 'Enables a function to save own created mission calls to use them as template.',
             nl: 'Maakt het mogelijk om zelfgemaakte inzetten op te slaan als sjabloon om ze later te gebruiken.'
         },

--- a/lss-manager-v3/lss-manager-v3.dev.js
+++ b/lss-manager-v3/lss-manager-v3.dev.js
@@ -303,7 +303,7 @@ lssm.Module = {
         },
         active: false,
         description: {
-            de: 'Funktion um sebst erstlle VGE zu speichern.',
+            de: 'Funktion um sebst erstellte VGE zu speichern.',
             en: 'Enables a function to save own created mission calls to use them as template.',
             nl: 'Maakt het mogelijk om zelfgemaakte inzetten op te slaan als sjabloon om ze later te gebruiken.'
         },


### PR DESCRIPTION
Hab einen gemeldeten Rechtschreibfehler in der deutschen Beschreibung des Moduls "Eigene VGEs speichern" korrigiert.