### PR TITLE
Neue Funktion für Module: isActive

### DIFF
--- a/lss-manager-v3/lss-manager-v3.dev.js
+++ b/lss-manager-v3/lss-manager-v3.dev.js
@@ -1282,6 +1282,9 @@ lssm.modules = {
         } catch (e) {
             console.log("On lssm_module load: " + e.message);
         }
+    },
+    isActive: function(e) {
+        return lssm.Module[e].active;
     }
 };
 


### PR DESCRIPTION
"isActive" gibt aus, ob ein Modul aktiv ist oder nicht.
Es verschönert die Abfrage, ob ein Modul aktiv ist, oder nicht. Wenn die Funktion nicht benötigt wird, einfach PR closen ohne zu mergen ;)

Grüße Jan