### PR TITLE
Links änderung

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Der LSS MANAGER v3 ist eine Erweiterung für das Spiel [leitstellenspiel.de](https://www.leitstellenspiel.de). Mit dieser Erweiterung wird ein Appstore zum Spiel hinzugefügt, welches das Installieren von Plugins ermöglicht. Dabei sind alle Funktionen Modular aufgebaut - man kann bis auf den letzten Baustein bestimmen, was man alles nutzen möchte.
 
 ### Wiki
-Im [Wiki](https://github.com/lostdesign/lss-manager-v3/wiki) findest du alles zur [Installation](https://github.com/lostdesign/lss-manager-v3/wiki/INSTALLATION), das [Versions Log](https://github.com/lostdesign/lss-manager-v3/wiki/VERSIONEN), die [FAQs](https://github.com/lostdesign/lss-manager-v3/wiki/FAQ) & wie man eigene [Plugins](https://github.com/lostdesign/lss-manager-v3/wiki/EIGENE-PLUGINS) in den Store bekommt.
+Im [Wiki](https://github.com/lostdesign/lss-manager-v3/wiki) findest du alles zur [Installation](https://github.com/LSS-Manager/lss-manager-v3/wiki/INSTALLATION), das [Versions Log](https://github.com/LSS-Manager/lss-manager-v3/wiki/VERSIONEN), die [FAQs](https://github.com/LSS-Manager/lss-manager-v3/wiki/FAQ) & wie man eigene [Plugins](https://github.com/LSS-Manager/lss-manager-v3/wiki/EIGENE-PLUGINS) in den Store bekommt.
 
 ### Funktionsumfang
   - Funktionserweiterungen


### PR DESCRIPTION
lost hatte ein paar Links auf das Wiki seines Accounts gelegt, sodass man über die Readme nicht mehr zum Wiki kam.
Im Wiki sind viele weitere Fehler, die man aber nicht Pullen kann