### PR TITLE
Fix for redesign-01.user.js

### DIFF
--- a/modules/lss-redesign-01/redesign-01.user.js
+++ b/modules/lss-redesign-01/redesign-01.user.js
@@ -204,7 +204,7 @@
         'margin-bottom: 10px !important;'+
       '}'+
       '#map {'+
-        'height: 550px;'+
+        'height: 525px;'+
       '}'+
       '#missions-panel-body {'+
         'height: 497px;'+


### PR DESCRIPTION
Resolutions above 1680x1050 have trouble correctly displaying this redesign layout. Reducing the height of the map from 550px to 525px would fix this problem.